### PR TITLE
Remove stray character which resulted in an IndentationError

### DIFF
--- a/library/fanshim/__init__.py
+++ b/library/fanshim/__init__.py
@@ -28,7 +28,7 @@ class FanShim():
         self._t_poll = None
 
         atexit.register(self._cleanup)
-8
+
         #Original Versiom
         #GPIO.setwarnings(False)
         #GPIO.setmode(GPIO.BCM)


### PR DESCRIPTION
Running `python3 automatic.py --on-threshold 46 --off-threshold 44 ...` resulted in:
```
File "/usr/local/lib/python3.7/dist-packages/fanshim-0.0.4-py3.7.egg/fanshim/__init__.py", line 38
    print("hollo")
    ^
IndentationError: unexpected indent
```